### PR TITLE
[PATCH]

### DIFF
--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -10,8 +10,9 @@ pub fn generate_installs() -> &'static str {
 const fs = require("fs");
 const path = require("path");
 const { exec } = require("child_process");
+const { homedir } = require("os");
 
-const cargoDir = path.dirname("$HOME" + ".cargo");
+const cargoDir = path.join(homedir(), ".cargo");
 
 // check if directory exists
 if (fs.existsSync(cargoDir)) {


### PR DESCRIPTION
At src/generators/mod.rs: cargoDir is just a dot on my MacOS Catalina + zsh.
May cause invalid un-installation.
Fixed with [os.homedir()](https://nodejs.org/api/os.html#oshomedir).